### PR TITLE
Display map marker at bottle origin

### DIFF
--- a/Bottlz/Bottle.swift
+++ b/Bottlz/Bottle.swift
@@ -12,9 +12,26 @@ struct Bottle: Codable, Identifiable {
     var id: UUID
     var created: Date
 
-    private var originRaw: GeoPoint
-    var origin: CLLocationCoordinate2D {
-        CLLocationCoordinate2D(latitude: originRaw.coordinates[0], longitude: originRaw.coordinates[1])
+    private var originRaw: GeoPoint?
+    var origin: CLLocationCoordinate2D
+
+    init(lat: Double, lon: Double) {
+        self.init(id: UUID(), created: Date(), lat: lat, lon: lon)
+    }
+
+    init(id: UUID, created: Date, lat: Double, lon: Double) {
+        self.id = id
+        self.created = created
+        self.origin = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.created = try container.decode(Date.self, forKey: .created)
+        self.originRaw = try container.decode(Bottle.GeoPoint.self, forKey: .originRaw)
+        self.origin = CLLocationCoordinate2D(latitude: originRaw!.coordinates[1],
+                                             longitude: originRaw!.coordinates[0])
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Bottlz/BottleFetcher.swift
+++ b/Bottlz/BottleFetcher.swift
@@ -10,7 +10,7 @@ import Foundation
 class BottleFetcher: ObservableObject {
     @Published var bottleData: [Bottle] = []
 
-    let baseURL = URL(string: "https://bottlz.azurewebsites.net")
+    let baseURL = URL(string: "https://bottlz.azurewebsites.net")!
     let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970

--- a/Bottlz/BottleMap.swift
+++ b/Bottlz/BottleMap.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import MapKit
 
 struct BottleMap: View {
+    var bottles: [Bottle]
 
     @State private var region = MKCoordinateRegion(
         center: LocationManager.currentLocation,
@@ -18,7 +19,11 @@ struct BottleMap: View {
     var body: some View {
         ZStack() {
             Map(coordinateRegion: $region, interactionModes: [.all],
-                showsUserLocation: true, userTrackingMode: .constant(.follow))
+                showsUserLocation: true, userTrackingMode: .constant(.follow),
+                annotationItems: bottles)
+            { bottle in
+                MapMarker(coordinate: bottle.origin)
+            }
             VStack {
                 Text("Region Position: (\(region.center.latitude), \(region.center.longitude))")
                 Text("Region Zoom: \(region.span.latitudeDelta)")
@@ -30,6 +35,11 @@ struct BottleMap: View {
 
 struct BottleMap_Previews: PreviewProvider {
     static var previews: some View {
-        BottleMap()
+        BottleMap(bottles: [
+            Bottle(lat: 42.451, lon: -76.481),
+            Bottle(lat: 42.451, lon: -76.479),
+            Bottle(lat: 42.449, lon: -76.481),
+            Bottle(lat: 42.449, lon: -76.479)
+        ])
     }
 }

--- a/Bottlz/ContentView.swift
+++ b/Bottlz/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 0.0) {
-            BottleMap()
+            BottleMap(bottles: bottleFetcher.bottleData)
                 .edgesIgnoringSafeArea(.all)
             Button {
                 showCreateBottle.toggle()
@@ -39,5 +39,6 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+            .environmentObject(BottleFetcher())
     }
 }


### PR DESCRIPTION
- Will probably replace these basic map markers with something bottle-specific later
- Improved bottle initializers for preview content. Origin is now stored as location and the GeoPoint struct is only used for decoding