### PR TITLE
Selecting and viewing bottles

### DIFF
--- a/Bottlz.xcodeproj/project.pbxproj
+++ b/Bottlz.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C4A4A02292087CA007413B1 /* ViewBottleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4A4A01292087CA007413B1 /* ViewBottleView.swift */; };
 		3C6329FE2915FA6200D41F96 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6329FD2915FA6200D41F96 /* ContentView.swift */; };
 		3C632A0029161A3600D41F96 /* CreateBottleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6329FF29161A3600D41F96 /* CreateBottleView.swift */; };
 		3C6CF4CD2909F0C0005C3973 /* BottlzApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6CF4CC2909F0C0005C3973 /* BottlzApp.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C4A4A01292087CA007413B1 /* ViewBottleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewBottleView.swift; sourceTree = "<group>"; };
 		3C6329FD2915FA6200D41F96 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3C6329FF29161A3600D41F96 /* CreateBottleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBottleView.swift; sourceTree = "<group>"; };
 		3C6CF4C92909F0C0005C3973 /* Bottlz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bottlz.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,6 +69,7 @@
 				3CD4D19E2916DDE300FC39D8 /* Bottle.swift */,
 				3C8B1F572918C1EE00BD0FCE /* BottleFetcher.swift */,
 				3C6329FF29161A3600D41F96 /* CreateBottleView.swift */,
+				3C4A4A01292087CA007413B1 /* ViewBottleView.swift */,
 				3C8D6D7D290CAE5100C5FE2A /* LocationManager.swift */,
 				3C6CF4D02909F0C2005C3973 /* Assets.xcassets */,
 				3C6CF4D22909F0C2005C3973 /* Preview Content */,
@@ -159,6 +162,7 @@
 				3CD4D19F2916DDE300FC39D8 /* Bottle.swift in Sources */,
 				3C6329FE2915FA6200D41F96 /* ContentView.swift in Sources */,
 				3C8D6D7E290CAE5100C5FE2A /* LocationManager.swift in Sources */,
+				3C4A4A02292087CA007413B1 /* ViewBottleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bottlz/BottleFetcher.swift
+++ b/Bottlz/BottleFetcher.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class BottleFetcher: ObservableObject {
     @Published var bottleData: [Bottle] = []
+    @Published var selectedBottle: Bottle? = nil
 
     let baseURL = URL(string: "https://bottlz.azurewebsites.net")!
     let decoder: JSONDecoder = {
@@ -16,6 +17,11 @@ class BottleFetcher: ObservableObject {
         decoder.dateDecodingStrategy = .millisecondsSince1970
         return decoder
     }()
+
+    init(bottleData: [Bottle] = [], selectedBottle: Bottle? = nil) {
+        self.bottleData = bottleData
+        self.selectedBottle = selectedBottle
+    }
 
     enum FetchError: Error {
         case badRequest

--- a/Bottlz/BottleMap.swift
+++ b/Bottlz/BottleMap.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import MapKit
 
 struct BottleMap: View {
-    var bottles: [Bottle]
+    @EnvironmentObject var bottleFetcher: BottleFetcher
+    @Binding var showViewBottle: Bool
 
     @State private var region = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 42.45, longitude: -76.48),
@@ -20,11 +21,13 @@ struct BottleMap: View {
         ZStack() {
             Map(coordinateRegion: $region, interactionModes: [.all],
                 showsUserLocation: true, userTrackingMode: .constant(.follow),
-                annotationItems: bottles)
+                annotationItems: bottleFetcher.bottleData)
             { bottle in
                 MapAnnotation(coordinate: bottle.origin) {
                     Button {
                         print("Bottle ID", bottle.id)
+                        bottleFetcher.selectedBottle = bottle
+                        showViewBottle = true
                     } label: {
                         Image("Bottle")
                             .resizable()
@@ -46,11 +49,14 @@ struct BottleMap: View {
 
 struct BottleMap_Previews: PreviewProvider {
     static var previews: some View {
-        BottleMap(bottles: [
-            Bottle(lat: 42.451, lon: -76.481),
-            Bottle(lat: 42.451, lon: -76.479),
-            Bottle(lat: 42.449, lon: -76.481),
-            Bottle(lat: 42.449, lon: -76.479)
-        ])
+        BottleMap(showViewBottle: .constant(false))
+            .environmentObject(BottleFetcher(
+                bottleData: [
+                    Bottle(lat: 42.451, lon: -76.481),
+                    Bottle(lat: 42.451, lon: -76.479),
+                    Bottle(lat: 42.449, lon: -76.481),
+                    Bottle(lat: 42.449, lon: -76.479)
+                ]
+            ))
     }
 }

--- a/Bottlz/ContentView.swift
+++ b/Bottlz/ContentView.swift
@@ -30,6 +30,10 @@ struct ContentView: View {
             CreateBottleView()
                 .presentationDetents([.fraction(0.3)])
         }
+        .sheet(isPresented: .constant(true)) {
+            ViewBottleView()
+                .presentationDetents([.fraction(0.75)])
+        }
         .task {
             try? await bottleFetcher.getAllBottles()
         }

--- a/Bottlz/ContentView.swift
+++ b/Bottlz/ContentView.swift
@@ -11,10 +11,11 @@ struct ContentView: View {
     @EnvironmentObject var bottleFetcher: BottleFetcher
 
     @State private var showCreateBottle = false
+    @State private var showViewBottle = false
 
     var body: some View {
         VStack(spacing: 0.0) {
-            BottleMap(bottles: bottleFetcher.bottleData)
+            BottleMap(showViewBottle: $showViewBottle)
                 .edgesIgnoringSafeArea(.all)
             Button {
                 showCreateBottle.toggle()
@@ -30,7 +31,8 @@ struct ContentView: View {
             CreateBottleView()
                 .presentationDetents([.fraction(0.3)])
         }
-        .sheet(isPresented: .constant(true)) {
+        .sheet(isPresented: $showViewBottle,
+               onDismiss: { bottleFetcher.selectedBottle = nil }) {
             ViewBottleView()
                 .presentationDetents([.fraction(0.75)])
         }

--- a/Bottlz/ViewBottleView.swift
+++ b/Bottlz/ViewBottleView.swift
@@ -1,0 +1,49 @@
+//
+//  ViewBottleView.swift
+//  Bottlz
+//
+//  Created by Changyuan Lin on 11/12/22.
+//
+
+import SwiftUI
+
+struct ViewBottleView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack {
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("View Bottle")
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.gray)
+                    }
+                }
+                .font(.title2)
+            }
+            Spacer()
+            Rectangle()
+                .aspectRatio(1.0, contentMode: .fit)
+            Spacer()
+            Button {
+                print("Pressed Edit")
+            } label: {
+                Text("Edit")
+                    .frame(maxWidth: .infinity)
+                    .padding(8)
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+}
+
+struct ViewBottleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ViewBottleView()
+    }
+}

--- a/Bottlz/ViewBottleView.swift
+++ b/Bottlz/ViewBottleView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ViewBottleView: View {
+    @EnvironmentObject var bottleFetcher: BottleFetcher
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -26,8 +27,12 @@ struct ViewBottleView: View {
                 .font(.title2)
             }
             Spacer()
-            Rectangle()
-                .aspectRatio(1.0, contentMode: .fit)
+            ZStack {
+                Rectangle()
+                    .aspectRatio(1.0, contentMode: .fit)
+                Text(bottleFetcher.selectedBottle?.id.uuidString ?? "None")
+                    .foregroundColor(.accentColor)
+            }
             Spacer()
             Button {
                 print("Pressed Edit")
@@ -45,5 +50,8 @@ struct ViewBottleView: View {
 struct ViewBottleView_Previews: PreviewProvider {
     static var previews: some View {
         ViewBottleView()
+            .environmentObject(BottleFetcher(
+                selectedBottle: Bottle(lat: 0.0, lon: 0.0)
+            ))
     }
 }


### PR DESCRIPTION
- Add `ViewBottleView` with a placeholder Rectangle for the image later, currently shows UUID
- Update `BottleFetcher` to have a selected bottle
- Tapping on a bottle on the map will show the bottom sheet for view bottle and will set the selected bottle
- Change of thinking from passing data to storing data in the environment object. The bottle map is passed the binding to open the bottom sheet.

![Screen Shot 2022-11-14 at 00 43 18](https://user-images.githubusercontent.com/22627336/201584255-bc0e32a2-6996-4b08-8249-e2cbf738f86a.png)
