### PR TITLE
Decode and display bottle route

### DIFF
--- a/Bottlz.xcodeproj/project.pbxproj
+++ b/Bottlz.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3C6CF4CF2909F0C0005C3973 /* BottleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6CF4CE2909F0C0005C3973 /* BottleMap.swift */; };
 		3C6CF4D12909F0C2005C3973 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C6CF4D02909F0C2005C3973 /* Assets.xcassets */; };
 		3C6CF4D42909F0C2005C3973 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C6CF4D32909F0C2005C3973 /* Preview Assets.xcassets */; };
+		3C8ADE3F292C52EC002FB2D8 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8ADE3E292C52EC002FB2D8 /* Route.swift */; };
 		3C8B1F582918C1EE00BD0FCE /* BottleFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8B1F572918C1EE00BD0FCE /* BottleFetcher.swift */; };
 		3C8D6D7E290CAE5100C5FE2A /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8D6D7D290CAE5100C5FE2A /* LocationManager.swift */; };
 		3CD4D19F2916DDE300FC39D8 /* Bottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD4D19E2916DDE300FC39D8 /* Bottle.swift */; };
@@ -28,6 +29,7 @@
 		3C6CF4CE2909F0C0005C3973 /* BottleMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleMap.swift; sourceTree = "<group>"; };
 		3C6CF4D02909F0C2005C3973 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3C6CF4D32909F0C2005C3973 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		3C8ADE3E292C52EC002FB2D8 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		3C8B1F572918C1EE00BD0FCE /* BottleFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleFetcher.swift; sourceTree = "<group>"; };
 		3C8D6D7D290CAE5100C5FE2A /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		3CD4D19E2916DDE300FC39D8 /* Bottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bottle.swift; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 				3C6CF4CE2909F0C0005C3973 /* BottleMap.swift */,
 				3C6329FD2915FA6200D41F96 /* ContentView.swift */,
 				3CD4D19E2916DDE300FC39D8 /* Bottle.swift */,
+				3C8ADE3E292C52EC002FB2D8 /* Route.swift */,
 				3C8B1F572918C1EE00BD0FCE /* BottleFetcher.swift */,
 				3C6329FF29161A3600D41F96 /* CreateBottleView.swift */,
 				3C4A4A01292087CA007413B1 /* ViewBottleView.swift */,
@@ -155,6 +158,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C8ADE3F292C52EC002FB2D8 /* Route.swift in Sources */,
 				3C6CF4CF2909F0C0005C3973 /* BottleMap.swift in Sources */,
 				3C6CF4CD2909F0C0005C3973 /* BottlzApp.swift in Sources */,
 				3C632A0029161A3600D41F96 /* CreateBottleView.swift in Sources */,

--- a/Bottlz/Bottle.swift
+++ b/Bottlz/Bottle.swift
@@ -38,6 +38,15 @@ struct Bottle: Codable, Identifiable {
         self.routes = try container.decode([Route].self, forKey: .routes)
     }
 
+    var routeAnnotations: [RouteAnnotation] {
+        routes.enumerated().flatMap { (routeIndex, route) in
+            route.route.enumerated().map { (pointIndex, point) in
+                RouteAnnotation(id: "\(self.id):\(routeIndex):\(pointIndex)",
+                                point: point, portion: Double(pointIndex) / Double(route.route.count))
+            }
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case created

--- a/Bottlz/Bottle.swift
+++ b/Bottlz/Bottle.swift
@@ -15,6 +15,8 @@ struct Bottle: Codable, Identifiable {
     private var originRaw: GeoPoint?
     var origin: CLLocationCoordinate2D
 
+    var routes: [Route]
+
     init(lat: Double, lon: Double) {
         self.init(id: UUID(), created: Date(), lat: lat, lon: lon)
     }
@@ -23,6 +25,7 @@ struct Bottle: Codable, Identifiable {
         self.id = id
         self.created = created
         self.origin = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        self.routes = []
     }
 
     init(from decoder: Decoder) throws {
@@ -32,12 +35,14 @@ struct Bottle: Codable, Identifiable {
         self.originRaw = try container.decode(Bottle.GeoPoint.self, forKey: .originRaw)
         self.origin = CLLocationCoordinate2D(latitude: originRaw!.coordinates[1],
                                              longitude: originRaw!.coordinates[0])
+        self.routes = try container.decode([Route].self, forKey: .routes)
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case created
         case originRaw = "origin"
+        case routes
     }
 
     private struct GeoPoint: Codable {

--- a/Bottlz/BottleMap.swift
+++ b/Bottlz/BottleMap.swift
@@ -21,7 +21,9 @@ struct BottleMap: View {
         ZStack() {
             Map(coordinateRegion: $region, interactionModes: [.all],
                 showsUserLocation: true, userTrackingMode: .constant(.follow),
-                annotationItems: bottleFetcher.bottleData)
+                annotationItems:
+//                    bottleFetcher.bottleData.flatMap { bottle in bottle.routeAnnotations })
+                    bottleFetcher.bottleData)
             { bottle in
                 MapAnnotation(coordinate: bottle.origin) {
                     Button {
@@ -38,6 +40,11 @@ struct BottleMap: View {
                             .shadow(radius: 4)
                     }
                 }
+//                MapAnnotation(coordinate: bottle.point) {
+//                    Circle()
+//                        .foregroundColor(Color(white: bottle.portion))
+//                        .frame(width: 3, height: 3)
+//                }
             }
             VStack {
                 Text("Region Position: (\(region.center.latitude), \(region.center.longitude))")

--- a/Bottlz/Route.swift
+++ b/Bottlz/Route.swift
@@ -5,9 +5,23 @@
 //  Created by Changyuan Lin on 11/21/22.
 //
 
-import Foundation
+import CoreLocation
 
 struct Route: Codable {
     var distance: Double
-    var route: [[Double]]
+    var routeRaw: [[Double]]
+    var route: [CLLocationCoordinate2D]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.distance = try container.decode(Double.self, forKey: .distance)
+        self.routeRaw = try container.decode([[Double]].self, forKey: .routeRaw)
+        self.route = self.routeRaw.map { pointPair in
+            CLLocationCoordinate2D(latitude: pointPair[1], longitude: pointPair[0]) }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case distance
+        case routeRaw = "route"
+    }
 }

--- a/Bottlz/Route.swift
+++ b/Bottlz/Route.swift
@@ -1,0 +1,13 @@
+//
+//  Route.swift
+//  Bottlz
+//
+//  Created by Changyuan Lin on 11/21/22.
+//
+
+import Foundation
+
+struct Route: Codable {
+    var distance: Double
+    var route: [[Double]]
+}

--- a/Bottlz/Route.swift
+++ b/Bottlz/Route.swift
@@ -25,3 +25,9 @@ struct Route: Codable {
         case routeRaw = "route"
     }
 }
+
+struct RouteAnnotation: Identifiable {
+    var id: String
+    var point: CLLocationCoordinate2D
+    var portion: Double
+}


### PR DESCRIPTION
- Decode route data from backend into `Route` type that has `[CLLocationCoordinate2D]`
- Test/debugging code (commented out but preserved) to render points in each bottle's routes. Warning: slow
![Screen Shot 2022-11-23 at 00 22 58](https://user-images.githubusercontent.com/22627336/203481417-7a54b1a6-4571-4a58-bc11-cd639d303cd5.png)
