### PR TITLE
Color bottles with no more routes red

### DIFF
--- a/Bottlz/Bottle.swift
+++ b/Bottlz/Bottle.swift
@@ -49,7 +49,15 @@ struct Bottle: Codable, Identifiable {
         }
     }
 
+    func isOutOfRoutes(currentDate: Date) -> Bool {
+        let coveredDistance = currentDate.timeIntervalSince(self.created) * Bottle.speed
+        let totalRouteDistance = routes.map({ route in route.distance }).reduce(0, +)
+        return coveredDistance >= totalRouteDistance
+    }
+
     func computeCurrentLocation(currentDate: Date) -> CLLocationCoordinate2D {
+        guard !routes.isEmpty else { return origin }
+
         let coveredDistance = currentDate.timeIntervalSince(self.created) * Bottle.speed
 
         var accumulatedDistance = 0.0

--- a/Bottlz/BottleMap.swift
+++ b/Bottlz/BottleMap.swift
@@ -37,7 +37,8 @@ struct BottleMap: View {
                         Image("Bottle")
                             .resizable()
                             .renderingMode(.template)
-                            .foregroundColor(.primary)
+                            .foregroundColor(
+                                bottle.isOutOfRoutes(currentDate: currentDate) ? .red : .primary)
                             .background(in: Circle())
                             .frame(width: 30.0, height: 30.0)
                             .shadow(radius: 4)


### PR DESCRIPTION
- Bottles with no more route geometry to travel will be colored red, defined as covered distance >= total route distance
- Add check for empty routes list, if there are no routes show up at the origin
- Mainly for dev purposes, ideally there should be no red bottles because bottles should always have another route to follow
![Screen Shot 2022-11-25 at 21 38 27](https://user-images.githubusercontent.com/22627336/204069414-c9157ded-6384-49e8-a6b1-87b90ec3e0f9.png)
