### PR TITLE
Send request to create bottle

### DIFF
--- a/Bottlz/BottleMap.swift
+++ b/Bottlz/BottleMap.swift
@@ -21,7 +21,7 @@ struct BottleMap: View {
     let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        ZStack() {
+        ZStack(alignment: .bottom) {
             Map(coordinateRegion: $region, interactionModes: [.all],
                 showsUserLocation: true, userTrackingMode: .constant(.follow),
                 annotationItems:

--- a/Bottlz/CreateBottleView.swift
+++ b/Bottlz/CreateBottleView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct CreateBottleView: View {
+    @EnvironmentObject var bottleFetcher: BottleFetcher
+    @EnvironmentObject var locationManager: LocationManager
     @Environment(\.dismiss) var dismiss
+
+    @State private var isCreatingBottle = false
 
     var body: some View {
         VStack {
@@ -30,12 +34,19 @@ struct CreateBottleView: View {
             Spacer()
             Button {
                 print("Pressed Confirm")
+                isCreatingBottle = true
+                Task {
+                    try await bottleFetcher.createBottle(location: locationManager.currentLocation)
+                    isCreatingBottle = false
+                    dismiss()
+                }
             } label: {
                 Text("Confirm")
                     .frame(maxWidth: .infinity)
                     .padding(8)
             }
             .buttonStyle(.bordered)
+            .disabled(isCreatingBottle)
         }
         .padding()
     }
@@ -44,5 +55,7 @@ struct CreateBottleView: View {
 struct CreateBottleView_Previews: PreviewProvider {
     static var previews: some View {
         CreateBottleView()
+            .environmentObject(BottleFetcher())
+            .environmentObject(LocationManager())
     }
 }


### PR DESCRIPTION
- Pressing "confirm" on the create bottle view now sends a request to `/bottles/create`
- Confirm button disabled until request completes
- New bottle is appended and appears on the map and starts following its route
- Move debug text on map out of the center

https://user-images.githubusercontent.com/22627336/204111473-f09ab077-bd9e-4750-b25f-b3db11097254.mov

